### PR TITLE
Fix exception for Twig filter method

### DIFF
--- a/src/TwigGenerator/Builder/BaseBuilder.php
+++ b/src/TwigGenerator/Builder/BaseBuilder.php
@@ -324,7 +324,14 @@ abstract class BaseBuilder implements BuilderInterface
     {
         foreach ($this->twigFilters as $twigFilter) {
             if (is_object($twigFilter)) {
-                $twig->addFilter($twigFilter);
+                if (method_exists($twigFilter, 'getName')) {
+                    $twig->addFilter($twigFilter);
+                } else {
+                    $filter = new \ReflectionObject($twigFilter);
+                    $name = $filter->getProperty('method');
+                    $name->setAccessible(true);
+                    $twig->addFilter($name->getValue($twigFilter), $twigFilter);
+                }
                 continue;
             } elseif (($pos = strpos($twigFilter, ':')) !== false) {
                 $twigFilterName = substr($twigFilter, $pos + 2);


### PR DESCRIPTION
`A filter must be an instance of Twig_FilterInterface or Twig_SimpleFilter`
